### PR TITLE
Fix for random selection and exclusion

### DIFF
--- a/cheekymonkey.py
+++ b/cheekymonkey.py
@@ -593,7 +593,7 @@ def main():
     # Process arguments
     parser = argparse.ArgumentParser(description='A Chaos Monkey for your Kubernetes cluster!')
     parser.add_argument("--offline", default="no", help="Set to yes to enable offline mode")
-    parser.add_argument('-e','--exclude', nargs='*', help='<Optional> Space-separated list of namespaces to NOT target')
+    parser.add_argument('-e','--exclude', nargs='*', default="", help='<Optional> Space-separated list of namespaces to NOT target')
 
     args = parser.parse_args()
     offline = args.offline

--- a/k8s_kill_pod.py
+++ b/k8s_kill_pod.py
@@ -32,14 +32,15 @@ def list_pods():
 
             # Select random pod
             # print(ret.items[0].metadata.namespace)
+            random.shuffle(ret.items)
             while ret.items[0].metadata.namespace in constants.EXCLUDES_LIST:
                 logging.info("Pod in excluded namespace, shuffling")
                 random.shuffle(ret.items)
             POD_TO_KILL = ret.items[0].metadata.name
             POD_NAMESPACE = ret.items[0].metadata.namespace
             return([POD_TO_KILL, POD_NAMESPACE])
-        except:
-            logging.error("Unable to list pods")
+        except Exception as e:
+            logging.error("Unable to list pods: %s" (e))
             return([0],[0])
 
 


### PR DESCRIPTION
This PR fixes 2 things:

- Random selection of pod (before it was always the first one, unless the first matches the exclusion)
- Default value of empty for exclude list (otherwise it throws a NoneType in the list_pods)